### PR TITLE
feat(discord): add discord to top nav, center styled base jump alert

### DIFF
--- a/packages/webapp/components/BaseJumpAnnouncement.tsx
+++ b/packages/webapp/components/BaseJumpAnnouncement.tsx
@@ -88,25 +88,27 @@ export const BaseAlertHeader = () => {
   useDisclosure({ defaultIsOpen: true });
 
   return (
-    <Alert variant="solid" style={{ marginBottom: "-40px", flexGrow: 1, alignItems: "center", background: "#FFE762" }}>
+    <Alert variant="solid" style={{ marginBottom: "-40px", flexGrow: 1, alignItems: "center", background: "#FFE762", maxHeight: '150px' }} flexFlow={{ base: 'column', md: 'row' }}>
       <Box flexGrow={1} alignContent={"center"}>
-        <AlertTitle textAlign={"center"} textStyle={"h2"} py={2}>
+        <AlertTitle textAlign={{ base: "center", md: 'center' }} textStyle={"h2"} py={2}>
           Gnars have BASE JUMPED!
         </AlertTitle>
         <AlertDescription textAlign={"center"}>
           <Text>We&#39;re currently updating this site to be fully operation on Base. Stay tuned. ⌐◨-◨\m/</Text>
         </AlertDescription>
       </Box>
-      <ExternalLink isExternal href={baseLink} rel="noopener noreferrer">
-        <Button
-          w={"fit-content"}
-          variant={"outline"}
-          style={{ borderColor: "#1A202C", color: "#1A202C" }}
-          rightIcon={<FiExternalLink />}
-        >
-          BASE JUMP!
-        </Button>
-      </ExternalLink>
+      <Box flexGrow={1} alignContent={{ base: "center", md: "flex-end" }}>
+        <ExternalLink isExternal href={baseLink} rel="noopener noreferrer" flexGrow={{ base: 1 }}>
+          <Button
+            w={"fit-content"}
+            variant={"outline"}
+            style={{ borderColor: "#1A202C", color: "#1A202C" }}
+            rightIcon={<FiExternalLink />}
+          >
+            BASE JUMP!
+          </Button>
+        </ExternalLink>
+      </Box>
     </Alert>
   );
 };

--- a/packages/webapp/components/Explainer.tsx
+++ b/packages/webapp/components/Explainer.tsx
@@ -27,7 +27,7 @@ const londrinaSolid = Londrina_Solid({
 export default function Explainer() {
   return (
     <Box color={"chakra-body-text"} bgColor={"chakra-body-bg"}>
-      <VStack px={[2, 6]} py={{ base: 10, sm: 32 }} spacing={{ base: 10, sm: 32 }} w={"full"} justifyContent={"center"}>
+      <VStack px={[2, 6]} py={{ base: 10, sm: 5, md: 32 }} spacing={{ base: 10, sm: 32 }} w={"full"} justifyContent={"center"}>
         <Stack
           px={0}
           w={"full"}
@@ -42,6 +42,9 @@ export default function Explainer() {
               base: "calc(60px + (128 - 60) * ((100vw - 375px) / (1280 - 375)))",
               xl: "8xl"
             }}
+            textAlign={{ base: "center", md: 'left' }}
+            alignSelf={{ base: 'center', md: 'inherit' }}
+            marginTop={{ xsm: -15, base: 10, sm: 32 }}
           >
             ONE GNAR,
             <br />

--- a/packages/webapp/components/Footer.tsx
+++ b/packages/webapp/components/Footer.tsx
@@ -129,7 +129,7 @@ export default function Footer() {
               <IconButton
                 as="a"
                 rel="external noopener"
-                href="https://discord.gg/XBeZuMxmst"
+                href="https://discord.com/invite/hasfzNpj"
                 aria-label="Discord"
                 icon={<FaDiscord fontSize="1.25rem" />}
               />

--- a/packages/webapp/components/Footer.tsx
+++ b/packages/webapp/components/Footer.tsx
@@ -129,7 +129,7 @@ export default function Footer() {
               <IconButton
                 as="a"
                 rel="external noopener"
-                href="https://discord.com/invite/hasfzNpj"
+                href="https://discord.gg/gnars"
                 aria-label="Discord"
                 icon={<FaDiscord fontSize="1.25rem" />}
               />

--- a/packages/webapp/components/Menu.tsx
+++ b/packages/webapp/components/Menu.tsx
@@ -3,9 +3,9 @@ import { GnarsLogo } from "./GnarsLogo";
 import { ShredIcon } from "./Icons";
 import { TreasuryBalance } from "./TreasuryBalance";
 import { WalletButton } from "./WalletButton";
-import { Button, Center, CenterProps, Link as ExternalLink, HStack, IconButton, Stack } from "@chakra-ui/react";
+import { Button, Center, CenterProps, Link as ExternalLink, HStack, IconButton, Stack, ButtonGroup } from "@chakra-ui/react";
 import Link from "next/link";
-import { FaBars, FaBookOpen, FaPlay, FaUsers } from "react-icons/fa";
+import { FaBars, FaBookOpen, FaPlay, FaUsers, FaDiscord } from "react-icons/fa";
 
 export type MenuProps = CenterProps;
 
@@ -65,11 +65,18 @@ export default function Menu(props: MenuProps) {
           </ExternalLink>
           <Link href="/playground">
             <Button w={"full"} variant={"outline"} leftIcon={<FaPlay />}>
-              Playground
+              {showMenu ? "Playground" : "Play"}
             </Button>
           </Link>
+          <ExternalLink href="https://discord.gg/gnars" isExternal rel="noopener noreferrer" aria-label="Discord">
+            <Button w={"full"} variant={"outline"} leftIcon={<FaDiscord fontSize="1.25rem" />}>
+              Discord
+            </Button>
+          </ExternalLink>
           <WalletButton hideFrom={"lg"} w="full" />
+
         </Stack>
+
         <WalletButton hideBelow={"lg"} />
       </Stack>
     </Center>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,0 +1,96 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      utf-8-validate:
+        specifier: ^5.0.2
+        version: 5.0.10
+    devDependencies:
+      turbo:
+        specifier: ^1.13.2
+        version: 1.13.4
+
+packages:
+
+  node-gyp-build@4.8.1:
+    resolution: {integrity: sha512-OSs33Z9yWr148JZcbZd5WiAXhh/n9z8TxQcdMhIOlpN9AhWpLfvVFO73+m77bBABQMaY9XSvIa+qk0jlI7Gcaw==}
+    hasBin: true
+
+  turbo-darwin-64@1.13.4:
+    resolution: {integrity: sha512-A0eKd73R7CGnRinTiS7txkMElg+R5rKFp9HV7baDiEL4xTG1FIg/56Vm7A5RVgg8UNgG2qNnrfatJtb+dRmNdw==}
+    cpu: [x64]
+    os: [darwin]
+
+  turbo-darwin-arm64@1.13.4:
+    resolution: {integrity: sha512-eG769Q0NF6/Vyjsr3mKCnkG/eW6dKMBZk6dxWOdrHfrg6QgfkBUk0WUUujzdtVPiUIvsh4l46vQrNVd9EOtbyA==}
+    cpu: [arm64]
+    os: [darwin]
+
+  turbo-linux-64@1.13.4:
+    resolution: {integrity: sha512-Bq0JphDeNw3XEi+Xb/e4xoKhs1DHN7OoLVUbTIQz+gazYjigVZvtwCvgrZI7eW9Xo1eOXM2zw2u1DGLLUfmGkQ==}
+    cpu: [x64]
+    os: [linux]
+
+  turbo-linux-arm64@1.13.4:
+    resolution: {integrity: sha512-BJcXw1DDiHO/okYbaNdcWN6szjXyHWx9d460v6fCHY65G8CyqGU3y2uUTPK89o8lq/b2C8NK0yZD+Vp0f9VoIg==}
+    cpu: [arm64]
+    os: [linux]
+
+  turbo-windows-64@1.13.4:
+    resolution: {integrity: sha512-OFFhXHOFLN7A78vD/dlVuuSSVEB3s9ZBj18Tm1hk3aW1HTWTuAw0ReN6ZNlVObZUHvGy8d57OAGGxf2bT3etQw==}
+    cpu: [x64]
+    os: [win32]
+
+  turbo-windows-arm64@1.13.4:
+    resolution: {integrity: sha512-u5A+VOKHswJJmJ8o8rcilBfU5U3Y1TTAfP9wX8bFh8teYF1ghP0EhtMRLjhtp6RPa+XCxHHVA2CiC3gbh5eg5g==}
+    cpu: [arm64]
+    os: [win32]
+
+  turbo@1.13.4:
+    resolution: {integrity: sha512-1q7+9UJABuBAHrcC4Sxp5lOqYS5mvxRrwa33wpIyM18hlOCpRD/fTJNxZ0vhbMcJmz15o9kkVm743mPn7p6jpQ==}
+    hasBin: true
+
+  utf-8-validate@5.0.10:
+    resolution: {integrity: sha512-Z6czzLq4u8fPOyx7TU6X3dvUZVvoJmxSQ+IcrlmagKhilxlhZgxPK6C5Jqbkw1IDUmFTM+cz9QDnnLTwDz/2gQ==}
+    engines: {node: '>=6.14.2'}
+
+snapshots:
+
+  node-gyp-build@4.8.1: {}
+
+  turbo-darwin-64@1.13.4:
+    optional: true
+
+  turbo-darwin-arm64@1.13.4:
+    optional: true
+
+  turbo-linux-64@1.13.4:
+    optional: true
+
+  turbo-linux-arm64@1.13.4:
+    optional: true
+
+  turbo-windows-64@1.13.4:
+    optional: true
+
+  turbo-windows-arm64@1.13.4:
+    optional: true
+
+  turbo@1.13.4:
+    optionalDependencies:
+      turbo-darwin-64: 1.13.4
+      turbo-darwin-arm64: 1.13.4
+      turbo-linux-64: 1.13.4
+      turbo-linux-arm64: 1.13.4
+      turbo-windows-64: 1.13.4
+      turbo-windows-arm64: 1.13.4
+
+  utf-8-validate@5.0.10:
+    dependencies:
+      node-gyp-build: 4.8.1


### PR DESCRIPTION
Merged from `dev-{feature-branch}` (#52)

## Description

- Added discord invite link https://discord.gg/gnars to nav bar and mobile menu for ease of onboarding more members in the community in upcoming marketing and outreach efforts.

- Fixed some mobile styling in the migrated to base alert bar.

* feat(discord): add discord to top nav, center styled base jump alert

---

### Desktop

<img width="600" alt="image" src="https://github.com/user-attachments/assets/2b662ad3-1d15-4e3a-bc11-a58800e72930">

### Mobile

<img width="300" alt="image" src="https://github.com/user-attachments/assets/493e213e-0342-458f-ad45-dce16d3a1406">

#### Mobile Menu

<img width="300" alt="image" src="https://github.com/user-attachments/assets/99743979-d6a0-4e39-b304-d9f43817efd0">
